### PR TITLE
Pass invites to the receive object

### DIFF
--- a/src/matrix-receive.js
+++ b/src/matrix-receive.js
@@ -32,6 +32,12 @@ module.exports = function(RED) {
             node.status({ fill: "green", shape: "ring", text: "connected" });
         });
 
+
+        node.server.on("Room.invite", async function(msg) {
+            node.send(msg);
+        });
+
+
         node.server.on("Room.timeline", async function(event, room, toStartOfTimeline, removed, data, msg) {
             // if node has a room ID set we only listen on that room
             if(node.roomIds.length && node.roomIds.indexOf(room.roomId) === -1) {

--- a/src/matrix-server-config.js
+++ b/src/matrix-server-config.js
@@ -239,6 +239,13 @@ module.exports = function(RED) {
                         });
                     } else {
                         node.log("Got invite to join room " + member.roomId);
+												let msg = {
+														type      : 'r.invite',
+														payload   : 'Invitation',
+														userId    : member.userId,
+														topic     : member.roomId
+												};
+												node.emit("Room.invite", msg);
                     }
                 }
             });


### PR DESCRIPTION
This commit passes a room invite to the receive node, so you can react to it. Solves #70 

Sample invitation:

<img width="302" alt="2022-11-25_20-57-29" src="https://user-images.githubusercontent.com/3321655/204050249-d462c127-6cef-47b7-a3cc-abb30b406fc8.png">

