### PR TITLE
Make errors catchable

### DIFF
--- a/src/matrix-create-room.js
+++ b/src/matrix-create-room.js
@@ -8,7 +8,7 @@ module.exports = function(RED) {
         this.server = RED.nodes.getNode(n.server);
 
         if(!this.server) {
-            node.error('Server must be configured on the node.');
+            node.error('Server must be configured on the node.', {});
             return;
         }
 
@@ -41,7 +41,7 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 

--- a/src/matrix-create-room.js
+++ b/src/matrix-create-room.js
@@ -11,6 +11,7 @@ module.exports = function(RED) {
             node.error('Server must be configured on the node.', {});
             return;
         }
+        node.server.register(node);
 
         this.encodeUri = function(pathTemplate, variables) {
             for (const key in variables) {
@@ -63,6 +64,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-create-room", MatrixCreateRoom);

--- a/src/matrix-create-room.js
+++ b/src/matrix-create-room.js
@@ -42,7 +42,7 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 

--- a/src/matrix-crypt-file.js
+++ b/src/matrix-crypt-file.js
@@ -12,22 +12,22 @@ module.exports = function(RED) {
             const { got } = await import('got');
 
             if(!msg.type) {
-                node.error('msg.type is required.');
+                node.error('msg.type is required.', msg);
                 return;
             }
 
             if(!msg.content) {
-                node.error('msg.content is required.');
+                node.error('msg.content is required.', msg);
                 return;
             }
 
             if(!msg.content.file) {
-                node.error('msg.content.file is required.');
+                node.error('msg.content.file is required.', msg);
                 return;
             }
 
             if(!msg.url) {
-                node.error('msg.url is required.');
+                node.error('msg.url is required.', msg);
                 return;
             }
 

--- a/src/matrix-delete-event.js
+++ b/src/matrix-delete-event.js
@@ -27,7 +27,7 @@ module.exports = function(RED) {
         node.on('input', function(msg) {
 
             if(!msg.eventId) {
-                node.error("eventId is missing");
+                node.error("eventId is missing", {});
                 node.send([null, msg])
                 return;
             }
@@ -38,7 +38,7 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
                 return;
             }

--- a/src/matrix-delete-event.js
+++ b/src/matrix-delete-event.js
@@ -13,6 +13,7 @@ module.exports = function(RED) {
             node.warn("No configuration node");
             return;
         }
+        node.server.register(node);
 
         node.status({ fill: "red", shape: "ring", text: "disconnected" });
 
@@ -69,6 +70,10 @@ module.exports = function(RED) {
                 msg.deleted = false
                 node.send([null, msg]);
             });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-delete-event",MatrixDeleteEvent);

--- a/src/matrix-delete-event.js
+++ b/src/matrix-delete-event.js
@@ -28,7 +28,7 @@ module.exports = function(RED) {
         node.on('input', function(msg) {
 
             if(!msg.eventId) {
-                node.error("eventId is missing", {});
+                node.error("eventId is missing", msg);
                 node.send([null, msg])
                 return;
             }
@@ -39,7 +39,7 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
                 return;
             }

--- a/src/matrix-invite-room.js
+++ b/src/matrix-invite-room.js
@@ -38,18 +38,18 @@ module.exports = function(RED) {
 
         node.on("input", function (msg) {
             if (! node.server || ! node.server.matrixClient) {
-                node.error("No matrix server selected", {});
+                node.error("No matrix server selected", msg);
                 return;
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 
             msg.topic = node.roomId || msg.topic;
             if(!msg.topic) {
-                node.error("room must be defined in either msg.topic or in node config", {});
+                node.error("room must be defined in either msg.topic or in node config", msg);
                 return;
             }
 

--- a/src/matrix-invite-room.js
+++ b/src/matrix-invite-room.js
@@ -12,6 +12,7 @@ module.exports = function(RED) {
             node.error('Server must be configured on the node.', {});
             return;
         }
+        node.server.register(node);
 
         this.encodeUri = function(pathTemplate, variables) {
             for (const key in variables) {
@@ -63,6 +64,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-invite-room", MatrixInviteRoom);

--- a/src/matrix-invite-room.js
+++ b/src/matrix-invite-room.js
@@ -9,7 +9,7 @@ module.exports = function(RED) {
         this.roomId = n.roomId;
 
         if(!this.server) {
-            node.error('Server must be configured on the node.');
+            node.error('Server must be configured on the node.', {});
             return;
         }
 
@@ -37,18 +37,18 @@ module.exports = function(RED) {
 
         node.on("input", function (msg) {
             if (! node.server || ! node.server.matrixClient) {
-                node.error("No matrix server selected");
+                node.error("No matrix server selected", {});
                 return;
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
             msg.topic = node.roomId || msg.topic;
             if(!msg.topic) {
-                node.error("room must be defined in either msg.topic or in node config");
+                node.error("room must be defined in either msg.topic or in node config", {});
                 return;
             }
 

--- a/src/matrix-join-room.js
+++ b/src/matrix-join-room.js
@@ -11,6 +11,7 @@ module.exports = function(RED) {
             node.warn("No configuration node");
             return;
         }
+        node.server.register(node);
 
         node.status({ fill: "red", shape: "ring", text: "disconnected" });
 
@@ -50,6 +51,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-join-room", MatrixJoinRoom);

--- a/src/matrix-join-room.js
+++ b/src/matrix-join-room.js
@@ -25,17 +25,17 @@ module.exports = function(RED) {
 
         node.on("input", function (msg) {
             if (! node.server || ! node.server.matrixClient) {
-                node.error("No matrix server selected", {});
+                node.error("No matrix server selected", msg);
                 return;
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 
             if(!msg.topic) {
-                node.error("Room must be specified in msg.topic", {});
+                node.error("Room must be specified in msg.topic", msg);
                 return;
             }
 
@@ -47,7 +47,7 @@ module.exports = function(RED) {
                     node.send([msg, null]);
                 })
                 .catch(function(e){
-                    node.error("Error trying to join room " + msg.topic + ":" + e, {});
+                    node.error("Error trying to join room " + msg.topic + ":" + e, msg);
                     msg.error = e;
                     node.send([null, msg]);
                 });

--- a/src/matrix-join-room.js
+++ b/src/matrix-join-room.js
@@ -24,17 +24,17 @@ module.exports = function(RED) {
 
         node.on("input", function (msg) {
             if (! node.server || ! node.server.matrixClient) {
-                node.error("No matrix server selected");
+                node.error("No matrix server selected", {});
                 return;
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
             if(!msg.topic) {
-                node.error("Room must be specified in msg.topic");
+                node.error("Room must be specified in msg.topic", {});
                 return;
             }
 
@@ -46,7 +46,7 @@ module.exports = function(RED) {
                     node.send([msg, null]);
                 })
                 .catch(function(e){
-                    node.error("Error trying to join room " + msg.topic + ":" + e);
+                    node.error("Error trying to join room " + msg.topic + ":" + e, {});
                     msg.error = e;
                     node.send([null, msg]);
                 });

--- a/src/matrix-leave-room.js
+++ b/src/matrix-leave-room.js
@@ -11,7 +11,7 @@ module.exports = function(RED) {
         node.status({ fill: "red", shape: "ring", text: "disconnected" });
 
         if (!node.server) {
-            node.error("No configuration node");
+            node.error("No configuration node", {});
             return;
         }
 
@@ -25,17 +25,17 @@ module.exports = function(RED) {
 
         node.on('input', function(msg) {
             if (! node.server || ! node.server.matrixClient) {
-                node.error("No matrix server selected");
+                node.error("No matrix server selected", {});
                 return;
             }
 
             if(!msg.topic) {
-                node.error('No room provided in msg.topic');
+                node.error('No room provided in msg.topic', {});
                 return;
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
@@ -44,7 +44,7 @@ module.exports = function(RED) {
                 node.server.matrixClient.leave(msg.topic);
                 node.send([msg, null]);
             } catch(e) {
-                node.error("Failed to leave room " + msg.topic + ": " + e);
+                node.error("Failed to leave room " + msg.topic + ": " + e, {});
                 msg.payload = e;
                 node.send([null, msg]);
             }

--- a/src/matrix-leave-room.js
+++ b/src/matrix-leave-room.js
@@ -26,17 +26,17 @@ module.exports = function(RED) {
 
         node.on('input', function(msg) {
             if (! node.server || ! node.server.matrixClient) {
-                node.error("No matrix server selected", {});
+                node.error("No matrix server selected", msg);
                 return;
             }
 
             if(!msg.topic) {
-                node.error('No room provided in msg.topic', {});
+                node.error('No room provided in msg.topic', msg);
                 return;
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 
@@ -45,7 +45,7 @@ module.exports = function(RED) {
                 node.server.matrixClient.leave(msg.topic);
                 node.send([msg, null]);
             } catch(e) {
-                node.error("Failed to leave room " + msg.topic + ": " + e, {});
+                node.error("Failed to leave room " + msg.topic + ": " + e, msg);
                 msg.payload = e;
                 node.send([null, msg]);
             }

--- a/src/matrix-leave-room.js
+++ b/src/matrix-leave-room.js
@@ -14,6 +14,7 @@ module.exports = function(RED) {
             node.error("No configuration node", {});
             return;
         }
+        node.server.register(node);
 
         node.server.on("disconnected", function(){
             node.status({ fill: "red", shape: "ring", text: "disconnected" });
@@ -48,6 +49,10 @@ module.exports = function(RED) {
                 msg.payload = e;
                 node.send([null, msg]);
             }
+        });
+        
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-leave-room", MatrixLeaveRoom);

--- a/src/matrix-react.js
+++ b/src/matrix-react.js
@@ -27,30 +27,30 @@ module.exports = function(RED) {
 
         node.on("input", function (msg) {
             if (!node.server || !node.server.matrixClient) {
-                node.error("No matrix server selected", {});
+                node.error("No matrix server selected", msg);
                 return;
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 
             msg.topic = node.roomId || msg.topic;
             if(!msg.topic) {
-                node.error("Room must be specified in msg.topic or in configuration", {});
+                node.error("Room must be specified in msg.topic or in configuration", msg);
                 return;
             }
 
             let payload = n.reaction || msg.payload;
             if(!payload) {
-                node.error('msg.payload must be defined or the reaction configured on the node.', {});
+                node.error('msg.payload must be defined or the reaction configured on the node.', msg);
                 return;
             }
 
             let eventId = msg.referenceEventId || msg.eventId;
             if(!eventId) {
-                node.error('Either msg.referenceEventId or msg.eventId must be defined to react to a message.', {});
+                node.error('Either msg.referenceEventId or msg.eventId must be defined to react to a message.', msg);
                 return;
             }
 

--- a/src/matrix-react.js
+++ b/src/matrix-react.js
@@ -13,6 +13,7 @@ module.exports = function(RED) {
             node.warn("No configuration node");
             return;
         }
+        node.server.register(node);
 
         node.status({ fill: "red", shape: "ring", text: "disconnected" });
 
@@ -74,6 +75,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-react", MatrixReact);

--- a/src/matrix-react.js
+++ b/src/matrix-react.js
@@ -26,30 +26,30 @@ module.exports = function(RED) {
 
         node.on("input", function (msg) {
             if (!node.server || !node.server.matrixClient) {
-                node.error("No matrix server selected");
+                node.error("No matrix server selected", {});
                 return;
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
             msg.topic = node.roomId || msg.topic;
             if(!msg.topic) {
-                node.error("Room must be specified in msg.topic or in configuration");
+                node.error("Room must be specified in msg.topic or in configuration", {});
                 return;
             }
 
             let payload = n.reaction || msg.payload;
             if(!payload) {
-                node.error('msg.payload must be defined or the reaction configured on the node.');
+                node.error('msg.payload must be defined or the reaction configured on the node.', {});
                 return;
             }
 
             let eventId = msg.referenceEventId || msg.eventId;
             if(!eventId) {
-                node.error('Either msg.referenceEventId or msg.eventId must be defined to react to a message.');
+                node.error('Either msg.referenceEventId or msg.eventId must be defined to react to a message.', {});
                 return;
             }
 

--- a/src/matrix-receive.js
+++ b/src/matrix-receive.js
@@ -24,6 +24,7 @@ module.exports = function(RED) {
             node.error("No configuration node", {});
             return;
         }
+        node.server.register(node);
 
         node.server.on("disconnected", function(){
             node.status({ fill: "red", shape: "ring", text: "disconnected" });
@@ -148,6 +149,10 @@ module.exports = function(RED) {
             }
 
             node.send(msg);
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-receive", MatrixReceiveMessage);

--- a/src/matrix-receive.js
+++ b/src/matrix-receive.js
@@ -21,7 +21,7 @@ module.exports = function(RED) {
         node.status({ fill: "red", shape: "ring", text: "disconnected" });
 
         if (!node.server) {
-            node.error("No configuration node");
+            node.error("No configuration node", {});
             return;
         }
 

--- a/src/matrix-room-ban.js
+++ b/src/matrix-room-ban.js
@@ -27,23 +27,23 @@ module.exports = function(RED) {
 
         node.on("input", function (msg) {
             if (! node.server || ! node.server.matrixClient) {
-                node.error("No matrix server selected", {});
+                node.error("No matrix server selected", msg);
                 return;
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 
             msg.topic = node.roomId || msg.topic;
             if(!msg.topic) {
-                node.error("Room must be specified in msg.topic or in configuration", {});
+                node.error("Room must be specified in msg.topic or in configuration", msg);
                 return;
             }
 
             if(!msg.userId) {
-                node.error("msg.userId was not set.", {});
+                node.error("msg.userId was not set.", msg);
                 return;
             }
 
@@ -54,7 +54,7 @@ module.exports = function(RED) {
                     node.send([msg, null]);
                 })
                 .catch(function(e){
-                    node.error("Error trying to ban " + msg.userId + " from " + msg.topic, {});
+                    node.error("Error trying to ban " + msg.userId + " from " + msg.topic, msg);
                     msg.error = e;
                     node.send([null, msg]);
                 });

--- a/src/matrix-room-ban.js
+++ b/src/matrix-room-ban.js
@@ -26,23 +26,23 @@ module.exports = function(RED) {
 
         node.on("input", function (msg) {
             if (! node.server || ! node.server.matrixClient) {
-                node.error("No matrix server selected");
+                node.error("No matrix server selected", {});
                 return;
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
             msg.topic = node.roomId || msg.topic;
             if(!msg.topic) {
-                node.error("Room must be specified in msg.topic or in configuration");
+                node.error("Room must be specified in msg.topic or in configuration", {});
                 return;
             }
 
             if(!msg.userId) {
-                node.error("msg.userId was not set.");
+                node.error("msg.userId was not set.", {});
                 return;
             }
 
@@ -53,7 +53,7 @@ module.exports = function(RED) {
                     node.send([msg, null]);
                 })
                 .catch(function(e){
-                    node.error("Error trying to ban " + msg.userId + " from " + msg.topic);
+                    node.error("Error trying to ban " + msg.userId + " from " + msg.topic, {});
                     msg.error = e;
                     node.send([null, msg]);
                 });

--- a/src/matrix-room-ban.js
+++ b/src/matrix-room-ban.js
@@ -13,6 +13,7 @@ module.exports = function(RED) {
             node.warn("No configuration node");
             return;
         }
+        node.server.register(node);
 
         node.status({ fill: "red", shape: "ring", text: "disconnected" });
 
@@ -57,6 +58,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-room-ban", MatrixBan);

--- a/src/matrix-room-invite.js
+++ b/src/matrix-room-invite.js
@@ -12,6 +12,7 @@ module.exports = function(RED) {
             node.error('Server must be configured on the node.', {});
             return;
         }
+        node.server.register(node);
 
         node.status({ fill: "red", shape: "ring", text: "disconnected" });
 
@@ -25,6 +26,10 @@ module.exports = function(RED) {
 
         node.server.on("Room.invite", async function(msg) {
             node.send(msg);
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-room-invite", MatrixRoomInvite);

--- a/src/matrix-room-invite.js
+++ b/src/matrix-room-invite.js
@@ -9,7 +9,7 @@ module.exports = function(RED) {
         this.roomId = n.roomId;
 
         if(!this.server) {
-            node.error('Server must be configured on the node.');
+            node.error('Server must be configured on the node.', {});
             return;
         }
 

--- a/src/matrix-room-kick.js
+++ b/src/matrix-room-kick.js
@@ -13,6 +13,7 @@ module.exports = function(RED) {
             node.warn("No configuration node");
             return;
         }
+        node.server.register(node);
 
         node.status({ fill: "red", shape: "ring", text: "disconnected" });
 
@@ -57,6 +58,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-room-kick", MatrixKick);

--- a/src/matrix-room-kick.js
+++ b/src/matrix-room-kick.js
@@ -26,23 +26,23 @@ module.exports = function(RED) {
 
         node.on("input", function (msg) {
             if (! node.server || ! node.server.matrixClient) {
-                node.error("No matrix server selected");
+                node.error("No matrix server selected", {});
                 return;
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
             msg.topic = node.roomId || msg.topic;
             if(!msg.topic) {
-                node.error("Room must be specified in msg.topic or in configuration");
+                node.error("Room must be specified in msg.topic or in configuration", {});
                 return;
             }
 
             if(!msg.userId) {
-                node.error("msg.userId was not set.");
+                node.error("msg.userId was not set.", {});
                 return;
             }
 
@@ -53,7 +53,7 @@ module.exports = function(RED) {
                     node.send([msg, null]);
                 })
                 .catch(function(e){
-                    node.error("Error trying to kick " + msg.userId + " from " + msg.topic);
+                    node.error("Error trying to kick " + msg.userId + " from " + msg.topic, {});
                     msg.error = e;
                     node.send([null, msg]);
                 });

--- a/src/matrix-room-kick.js
+++ b/src/matrix-room-kick.js
@@ -27,23 +27,23 @@ module.exports = function(RED) {
 
         node.on("input", function (msg) {
             if (! node.server || ! node.server.matrixClient) {
-                node.error("No matrix server selected", {});
+                node.error("No matrix server selected", msg);
                 return;
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 
             msg.topic = node.roomId || msg.topic;
             if(!msg.topic) {
-                node.error("Room must be specified in msg.topic or in configuration", {});
+                node.error("Room must be specified in msg.topic or in configuration", msg);
                 return;
             }
 
             if(!msg.userId) {
-                node.error("msg.userId was not set.", {});
+                node.error("msg.userId was not set.", msg);
                 return;
             }
 
@@ -54,7 +54,7 @@ module.exports = function(RED) {
                     node.send([msg, null]);
                 })
                 .catch(function(e){
-                    node.error("Error trying to kick " + msg.userId + " from " + msg.topic, {});
+                    node.error("Error trying to kick " + msg.userId + " from " + msg.topic, msg);
                     msg.error = e;
                     node.send([null, msg]);
                 });

--- a/src/matrix-room-users.js
+++ b/src/matrix-room-users.js
@@ -31,13 +31,13 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
             let roomId = node.roomId || msg.topic;
             if(!roomId) {
-                node.error("msg.topic is required. Specify in the input or configure the room ID on the node.");
+                node.error("msg.topic is required. Specify in the input or configure the room ID on the node.", {});
                 return;
             }
 

--- a/src/matrix-room-users.js
+++ b/src/matrix-room-users.js
@@ -32,13 +32,13 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 
             let roomId = node.roomId || msg.topic;
             if(!roomId) {
-                node.error("msg.topic is required. Specify in the input or configure the room ID on the node.", {});
+                node.error("msg.topic is required. Specify in the input or configure the room ID on the node.", msg);
                 return;
             }
 

--- a/src/matrix-room-users.js
+++ b/src/matrix-room-users.js
@@ -13,6 +13,7 @@ module.exports = function(RED) {
             node.warn("No configuration node");
             return;
         }
+        node.server.register(node);
 
         node.status({ fill: "red", shape: "ring", text: "disconnected" });
 
@@ -64,6 +65,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-room-users", MatrixRoomUsers);

--- a/src/matrix-send-file.js
+++ b/src/matrix-send-file.js
@@ -31,7 +31,7 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
@@ -57,7 +57,7 @@ module.exports = function(RED) {
             }
 
             if(!msg.payload) {
-                node.error('msg.payload is required');
+                node.error('msg.payload is required', {});
                 return;
             }
 

--- a/src/matrix-send-file.js
+++ b/src/matrix-send-file.js
@@ -13,6 +13,7 @@ module.exports = function(RED) {
             node.warn("No configuration node");
             return;
         }
+        node.server.register(node);
 
         node.status({ fill: "red", shape: "ring", text: "disconnected" });
 
@@ -93,6 +94,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-send-file", MatrixSendFile);

--- a/src/matrix-send-file.js
+++ b/src/matrix-send-file.js
@@ -32,7 +32,7 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 
@@ -58,7 +58,7 @@ module.exports = function(RED) {
             }
 
             if(!msg.payload) {
-                node.error('msg.payload is required', {});
+                node.error('msg.payload is required', msg);
                 return;
             }
 

--- a/src/matrix-send-image.js
+++ b/src/matrix-send-image.js
@@ -31,7 +31,7 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
@@ -57,7 +57,7 @@ module.exports = function(RED) {
             }
 
             if(!msg.payload) {
-                node.error('msg.payload is required');
+                node.error('msg.payload is required', {});
                 return;
             }
 

--- a/src/matrix-send-image.js
+++ b/src/matrix-send-image.js
@@ -32,7 +32,7 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 
@@ -58,7 +58,7 @@ module.exports = function(RED) {
             }
 
             if(!msg.payload) {
-                node.error('msg.payload is required', {});
+                node.error('msg.payload is required', msg);
                 return;
             }
 

--- a/src/matrix-send-image.js
+++ b/src/matrix-send-image.js
@@ -13,6 +13,7 @@ module.exports = function(RED) {
             node.warn("No configuration node");
             return;
         }
+        node.server.register(node);
 
         node.status({ fill: "red", shape: "ring", text: "disconnected" });
 
@@ -97,6 +98,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-send-image", MatrixSendImage);

--- a/src/matrix-send-message.js
+++ b/src/matrix-send-message.js
@@ -54,6 +54,7 @@ module.exports = function(RED) {
             node.warn("No configuration node");
             return;
         }
+        node.server.register(node);
 
         node.status({ fill: "red", shape: "ring", text: "disconnected" });
 
@@ -151,6 +152,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-send-message", MatrixSendImage);

--- a/src/matrix-send-message.js
+++ b/src/matrix-send-message.js
@@ -72,7 +72,7 @@ module.exports = function(RED) {
 
             if(msgType === 'msg.type') {
                 if(!msg.type) {
-                    node.error("msg.type type is set to be passed in via msg.type but was not defined", {});
+                    node.error("msg.type type is set to be passed in via msg.type but was not defined", msg);
                     return;
                 }
                 msgType = msg.type;
@@ -80,7 +80,7 @@ module.exports = function(RED) {
 
             if(msgFormat === 'msg.format') {
                 if(!msg.format) {
-                    node.error("Message format is set to be passed in via msg.format but was not defined", {});
+                    node.error("Message format is set to be passed in via msg.format but was not defined", msg);
                     return;
                 }
                 msgFormat = msg.format;
@@ -92,7 +92,7 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
                 return;
             }
@@ -105,7 +105,7 @@ module.exports = function(RED) {
 
             let payload = n.message || msg.payload;
             if(!payload) {
-                node.error('msg.payload must be defined or the message configured on the node.', {});
+                node.error('msg.payload must be defined or the message configured on the node.', msg);
                 return;
             }
 

--- a/src/matrix-send-message.js
+++ b/src/matrix-send-message.js
@@ -71,7 +71,7 @@ module.exports = function(RED) {
 
             if(msgType === 'msg.type') {
                 if(!msg.type) {
-                    node.error("msg.type type is set to be passed in via msg.type but was not defined");
+                    node.error("msg.type type is set to be passed in via msg.type but was not defined", {});
                     return;
                 }
                 msgType = msg.type;
@@ -79,7 +79,7 @@ module.exports = function(RED) {
 
             if(msgFormat === 'msg.format') {
                 if(!msg.format) {
-                    node.error("Message format is set to be passed in via msg.format but was not defined");
+                    node.error("Message format is set to be passed in via msg.format but was not defined", {});
                     return;
                 }
                 msgFormat = msg.format;
@@ -91,7 +91,7 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
                 return;
             }
@@ -104,7 +104,7 @@ module.exports = function(RED) {
 
             let payload = n.message || msg.payload;
             if(!payload) {
-                node.error('msg.payload must be defined or the message configured on the node.');
+                node.error('msg.payload must be defined or the message configured on the node.', {});
                 return;
             }
 

--- a/src/matrix-server-config.js
+++ b/src/matrix-server-config.js
@@ -44,6 +44,7 @@ module.exports = function(RED) {
             this.credentials = {};
         }
 
+        this.users = {};
         this.connected = null;
         this.name = n.name;
         this.userId = this.credentials.userId;
@@ -423,6 +424,14 @@ module.exports = function(RED) {
                         }
                     )
             })();
+
+            // Keep track of all consumers of this node to be able to catch errors
+            node.register = function(consumerNode) {
+                node.users[consumerNode.id] = consumerNode;
+            };
+            node.deregister = function(consumerNode) {
+                delete node.users[consumerNode.id];
+            };
         }
     }
 

--- a/src/matrix-server-config.js
+++ b/src/matrix-server-config.js
@@ -69,9 +69,9 @@ module.exports = function(RED) {
         let retryStartTimeout = null;
 
         if(!this.credentials.accessToken) {
-            node.error("Matrix connection failed: missing access token in configuration.");
+            node.error("Matrix connection failed: missing access token in configuration.", {});
         } else if(!this.url) {
-            node.error("Matrix connection failed: missing server URL in configuration.");
+            node.error("Matrix connection failed: missing server URL in configuration.", {});
         } else {
             node.setConnected = async function(connected, cb) {
                 if (node.connected !== connected) {
@@ -89,7 +89,7 @@ module.exports = function(RED) {
                                 device_id = this.matrixClient.getDeviceId();
 
                             if(!device_id && node.enableE2ee) {
-                                node.error("Failed to auto detect deviceId for this auth token. You will need to manually specify one. You may need to login to create a new deviceId.")
+                                node.error("Failed to auto detect deviceId for this auth token. You will need to manually specify one. You may need to login to create a new deviceId.", {})
                             } else {
                                 if(!stored_device_id || stored_device_id !== device_id) {
                                     node.log(`Saving Device ID (old:${stored_device_id} new:${device_id})`);
@@ -108,13 +108,13 @@ module.exports = function(RED) {
                                                     }).then(
                                                         function(response) {},
                                                         function(error) {
-                                                            node.error("Failed to set device label: " + error);
+                                                            node.error("Failed to set device label: " + error, {});
                                                         }
                                                     );
                                                 }
                                             },
                                             function(error) {
-                                                node.error("Failed to fetch device: " + error);
+                                                node.error("Failed to fetch device: " + error, {});
                                             }
                                         );
                                 }
@@ -190,7 +190,7 @@ module.exports = function(RED) {
                 try {
                     await node.matrixClient.decryptEventIfNeeded(event);
                 } catch (error) {
-                    node.error(error);
+                    node.error(error, {});
                     return;
                 }
 
@@ -293,7 +293,7 @@ module.exports = function(RED) {
                 } else if(prevState === null && state === "ERROR") {
                     // Occurs when the initial sync failed first time.
                     node.setConnected(false, function(){
-                        node.error("Failed to connect to Matrix server");
+                        node.error("Failed to connect to Matrix server", {});
                     });
                 } else if(prevState === "ERROR" && state === "PREPARED") {
                     // Occurs when the initial sync succeeds
@@ -310,18 +310,18 @@ module.exports = function(RED) {
                 } else if(prevState === "SYNCING" && state === "RECONNECTING") {
                     // Occurs when the live update fails.
                     node.setConnected(false, function(){
-                        node.error("Connection to Matrix server lost");
+                        node.error("Connection to Matrix server lost", {});
                     });
                 } else if(prevState === "RECONNECTING" && state === "RECONNECTING") {
                     // Can occur if the update calls continue to fail,
                     // but the keepalive calls (to /versions) succeed.
                     node.setConnected(false, function(){
-                        node.error("Connection to Matrix server lost");
+                        node.error("Connection to Matrix server lost", {});
                     });
                 } else if(prevState === "RECONNECTING" && state === "ERROR") {
                     // Occurs when the keepalive call also fails
                     node.setConnected(false, function(){
-                        node.error("Connection to Matrix server lost");
+                        node.error("Connection to Matrix server lost", {});
                     });
                 } else if(prevState === "ERROR" && state === "SYNCING") {
                     // Occurs when the client has performed a
@@ -333,7 +333,7 @@ module.exports = function(RED) {
                     // Occurs when the client has failed to
                     // keepalive for a second time or more.
                     node.setConnected(false, function(){
-                        node.error("Connection to Matrix server lost");
+                        node.error("Connection to Matrix server lost", {});
                     });
                 } else if(prevState === "SYNCING" && state === "SYNCING") {
                     // Occurs when the client has performed a live update.
@@ -345,7 +345,7 @@ module.exports = function(RED) {
                     // Occurs once the client has stopped syncing or
                     // trying to sync after stopClient has been called.
                     node.setConnected(false, function(){
-                        node.error("Connection to Matrix server lost");
+                        node.error("Connection to Matrix server lost", {});
                     });
                 }
             });
@@ -363,7 +363,7 @@ module.exports = function(RED) {
                 //     httpStatus: 401
                 // }
 
-                node.error("Authentication failure: " + errorObj);
+                node.error("Authentication failure: " + errorObj, {});
                 stopClient();
             });
 
@@ -379,7 +379,7 @@ module.exports = function(RED) {
                         initialSyncLimit: 8
                     });
                 } catch(error) {
-                    node.error(error);
+                    node.error(error, {});
                 }
             }
 
@@ -400,7 +400,7 @@ module.exports = function(RED) {
                     .then(
                         function(data) {
                             if((typeof data['device_id'] === undefined || !data['device_id']) && !node.deviceId && !getStoredDeviceId(localStorage)) {
-                                node.error("/whoami request did not return device_id. You will need to manually set one in your configuration because this cannot be automatically fetched.");
+                                node.error("/whoami request did not return device_id. You will need to manually set one in your configuration because this cannot be automatically fetched.", {});
                             }
                             if('device_id' in data && data['device_id'] && !node.deviceId) {
                                 // if we have no device_id configured lets use the one
@@ -410,7 +410,7 @@ module.exports = function(RED) {
 
                             // make sure our userId matches the access token's
                             if(data['user_id'].toLowerCase() !== node.userId.toLowerCase()) {
-                                node.error(`User ID provided is ${node.userId} but token belongs to ${data['user_id']}`);
+                                node.error(`User ID provided is ${node.userId} but token belongs to ${data['user_id']}`, {});
                                 return;
                             }
                             run().catch((error) => node.error(error));
@@ -419,7 +419,7 @@ module.exports = function(RED) {
                             // if the error isn't authentication related retry in a little bit
                             if(err.code !== "M_UNKNOWN_TOKEN") {
                                 retryStartTimeout = setTimeout(checkAuthTokenThenStart, 15000);
-                                node.error("Auth check failed: " + err);
+                                node.error("Auth check failed: " + err, {});
                             }
                         }
                     )
@@ -503,7 +503,7 @@ module.exports = function(RED) {
                         fs.copySync(oldStorageDir, dir);
                     }
                 } catch (err) {
-                    node.error(err);
+                    node.error(err, {});
                 }
             });
 

--- a/src/matrix-synapse-create-edit-user.js
+++ b/src/matrix-synapse-create-edit-user.js
@@ -42,12 +42,12 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 
             if(!msg.userId) {
-                node.error("msg.userId must be set to edit/create a user (ex: @user:server.com)", {});
+                node.error("msg.userId must be set to edit/create a user (ex: @user:server.com)", msg);
                 return;
             }
 

--- a/src/matrix-synapse-create-edit-user.js
+++ b/src/matrix-synapse-create-edit-user.js
@@ -8,9 +8,10 @@ module.exports = function(RED) {
         this.server = RED.nodes.getNode(n.server);
 
         if(!this.server) {
-            node.error('Server must be configured on the node.');
+            node.error('Server must be configured on the node.', {});
             return;
         }
+        node.server.register(node);
 
         this.encodeUri = function(pathTemplate, variables) {
             for (const key in variables) {
@@ -41,12 +42,12 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
             if(!msg.userId) {
-                node.error("msg.userId must be set to edit/create a user (ex: @user:server.com)");
+                node.error("msg.userId must be set to edit/create a user (ex: @user:server.com)", {});
                 return;
             }
 
@@ -68,6 +69,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-synapse-create-edit-user", MatrixSynapseCreateEditUser);

--- a/src/matrix-synapse-deactivate-user.js
+++ b/src/matrix-synapse-deactivate-user.js
@@ -8,9 +8,10 @@ module.exports = function(RED) {
         this.server = RED.nodes.getNode(n.server);
 
         if(!this.server) {
-            node.error('Server must be configured on the node.');
+            node.error('Server must be configured on the node.', {});
             return;
         }
+        node.server.register(node);
 
         this.encodeUri = function(pathTemplate, variables) {
             for (const key in variables) {
@@ -41,12 +42,12 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
             if(!msg.userId) {
-                node.error("msg.userId must be set to edit/create a user (ex: @user:server.com)");
+                node.error("msg.userId must be set to edit/create a user (ex: @user:server.com)", {});
                 return;
             }
 
@@ -69,6 +70,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-synapse-deactivate-user", MatrixSynapseDeactivateUser);

--- a/src/matrix-synapse-deactivate-user.js
+++ b/src/matrix-synapse-deactivate-user.js
@@ -42,12 +42,12 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 
             if(!msg.userId) {
-                node.error("msg.userId must be set to edit/create a user (ex: @user:server.com)", {});
+                node.error("msg.userId must be set to edit/create a user (ex: @user:server.com)", msg);
                 return;
             }
 

--- a/src/matrix-synapse-join-room.js
+++ b/src/matrix-synapse-join-room.js
@@ -9,10 +9,9 @@ module.exports = function(RED) {
         this.roomId = n.roomId;
 
         if(!this.server) {
-            node.error('Server must be configured on the node.');
+            node.error('Server must be configured on the node.', {});
             return;
         }
-
         this.encodeUri = function(pathTemplate, variables) {
             for (const key in variables) {
                 if (!variables.hasOwnProperty(key)) {
@@ -42,18 +41,18 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
             msg.topic = node.roomId || msg.topic;
             if(!msg.topic) {
-                node.error("room must be defined in either msg.topic or in node config");
+                node.error("room must be defined in either msg.topic or in node config", {});
                 return;
             }
 
             if(!msg.userId) {
-                node.error("msg.userId is required to set user into a room");
+                node.error("msg.userId is required to set user into a room", {});
                 return;
             }
 
@@ -76,6 +75,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-synapse-join-room", MatrixJoinRoom);

--- a/src/matrix-synapse-join-room.js
+++ b/src/matrix-synapse-join-room.js
@@ -41,18 +41,18 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 
             msg.topic = node.roomId || msg.topic;
             if(!msg.topic) {
-                node.error("room must be defined in either msg.topic or in node config", {});
+                node.error("room must be defined in either msg.topic or in node config", msg);
                 return;
             }
 
             if(!msg.userId) {
-                node.error("msg.userId is required to set user into a room", {});
+                node.error("msg.userId is required to set user into a room", msg);
                 return;
             }
 

--- a/src/matrix-synapse-register.js
+++ b/src/matrix-synapse-register.js
@@ -12,25 +12,27 @@ module.exports = function(RED) {
         this.sharedSecret = this.credentials.sharedSecret;
 
         if(!this.server) {
-            node.error('Server URL must be configured on the node.');
+            node.error('Server URL must be configured on the node.', {});
             return;
         }
 
         if(!this.sharedSecret) {
-            node.error('Shared registration secret must be configured on the node.');
+            node.error('Shared registration secret must be configured on the node.', {});
             return;
         }
+
+        node.server.register(node);
 
         node.on("input", async function (msg) {
             const { got } = await import('got');
 
             if(!msg.payload.username) {
-                node.error("msg.payload.username is required");
+                node.error("msg.payload.username is required", {});
                 return;
             }
 
             if(!msg.payload.password) {
-                node.error("msg.payload.password is required");
+                node.error("msg.payload.password is required", {});
                 return;
             }
 
@@ -50,7 +52,7 @@ module.exports = function(RED) {
 
                 var nonce = response.body.nonce;
                 if(!nonce) {
-                    node.error('Could not get nonce from /_synapse/admin/v1/register');
+                    node.error('Could not get nonce from /_synapse/admin/v1/register', {});
                     return;
                 }
 
@@ -95,6 +97,10 @@ module.exports = function(RED) {
                 msg.payload = response.body;
                 node.send(msg);
             })();
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-synapse-register", MatrixSynapseRegister, {

--- a/src/matrix-synapse-register.js
+++ b/src/matrix-synapse-register.js
@@ -27,12 +27,12 @@ module.exports = function(RED) {
             const { got } = await import('got');
 
             if(!msg.payload.username) {
-                node.error("msg.payload.username is required", {});
+                node.error("msg.payload.username is required", msg);
                 return;
             }
 
             if(!msg.payload.password) {
-                node.error("msg.payload.password is required", {});
+                node.error("msg.payload.password is required", msg);
                 return;
             }
 
@@ -52,7 +52,7 @@ module.exports = function(RED) {
 
                 var nonce = response.body.nonce;
                 if(!nonce) {
-                    node.error('Could not get nonce from /_synapse/admin/v1/register', {});
+                    node.error('Could not get nonce from /_synapse/admin/v1/register', msg);
                     return;
                 }
 

--- a/src/matrix-synapse-users.js
+++ b/src/matrix-synapse-users.js
@@ -31,7 +31,7 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 

--- a/src/matrix-synapse-users.js
+++ b/src/matrix-synapse-users.js
@@ -12,6 +12,8 @@ module.exports = function(RED) {
             return;
         }
 
+        node.server.register(node);
+
         node.status({ fill: "red", shape: "ring", text: "disconnected" });
 
         node.server.on("disconnected", function(){
@@ -29,7 +31,7 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
@@ -61,6 +63,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-synapse-users", MatrixSynapseUsers);

--- a/src/matrix-whois-user.js
+++ b/src/matrix-whois-user.js
@@ -43,12 +43,12 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed", {});
+                node.error("Matrix server connection is currently closed", msg);
                 node.send([null, msg]);
             }
 
             if(!msg.userId) {
-                node.error("msg.userId must be set to get user whois data", {});
+                node.error("msg.userId must be set to get user whois data", msg);
                 return;
             }
 

--- a/src/matrix-whois-user.js
+++ b/src/matrix-whois-user.js
@@ -8,9 +8,11 @@ module.exports = function(RED) {
         this.server = RED.nodes.getNode(n.server);
 
         if(!this.server) {
-            node.error('Server must be configured on the node.');
+            node.error('Server must be configured on the node.', {});
             return;
         }
+
+        node.server.register(node);
 
         this.encodeUri = function(pathTemplate, variables) {
             for (const key in variables) {
@@ -41,12 +43,12 @@ module.exports = function(RED) {
             }
 
             if(!node.server.isConnected()) {
-                node.error("Matrix server connection is currently closed");
+                node.error("Matrix server connection is currently closed", {});
                 node.send([null, msg]);
             }
 
             if(!msg.userId) {
-                node.error("msg.userId must be set to get user whois data");
+                node.error("msg.userId must be set to get user whois data", {});
                 return;
             }
 
@@ -69,6 +71,10 @@ module.exports = function(RED) {
                     msg.error = e;
                     node.send([null, msg]);
                 });
+        });
+
+        node.on("close", function() {
+            node.server.deregister(node);
         });
     }
     RED.nodes.registerType("matrix-whois-user", MatrixWhoIsUser);


### PR DESCRIPTION
Fixes #85 (errors are not catchable)

One downside though. At this moment Node-RED doesn't log errors on the config-node when no catch-node is available. [Issue 4219](https://github.com/node-red/node-red/issues/4219). Other nodes work well.
Until this is fixed in Node-RED, it is required to have a catch-node in order to view the errors of the config-node.