### PR TITLE
Add option for allowing unknown devices in rooms

### DIFF
--- a/src/matrix-server-config.html
+++ b/src/matrix-server-config.html
@@ -36,7 +36,8 @@
             name: { value: null },
             autoAcceptRoomInvites: { value: true },
             enableE2ee: { type: "checkbox", value: true },
-            global: { type: "checkbox", value: true }
+            global: { type: "checkbox", value: true },
+            allowUnknownDevices: { type: "checkbox", value: false }
         },
         icon: "matrix.png",
         label: function() {
@@ -128,6 +129,20 @@
         <div class="form-tips" style="margin-bottom: 12px;">
             If global access is enabled you can access the client directly within a Function node. This way you can do <a href="https://github.com/Skylar-Tech/node-red-contrib-matrix-chat/tree/master/examples#use-function-node-to-run-any-command" target="_blank">whatever you want</a> with the client. Example:<br>
             <code style="white-space: normal;">let client = global.get("matrixClient['@bot:example.com']");</code>
+        </div>
+    </div>
+
+    <div class="form-row">
+        <input
+                type="checkbox"
+                id="node-config-input-allowUnknownDevices"
+                style="width: auto; margin-left: 125px; vertical-align: top"
+        />
+        <label for="node-config-input-allowUnknownDevices" style="width: auto">
+            Allow unverified devices in rooms
+        </label>
+        <div class="form-tips" style="margin-bottom: 12px;">
+            Allow sending messages to a room with unknown devices which have not been verified.
         </div>
     </div>
     <script type="text/javascript">

--- a/src/matrix-server-config.js
+++ b/src/matrix-server-config.js
@@ -56,6 +56,7 @@ module.exports = function(RED) {
         this.autoAcceptRoomInvites = n.autoAcceptRoomInvites;
         this.e2ee = n.enableE2ee || false;
         this.globalAccess = n.global;
+        this.allowUnknownDevices = n.allowUnknownDevices || false;
         this.initializedAt = new Date();
         node.initialSyncLimit = 25;
 
@@ -401,6 +402,7 @@ module.exports = function(RED) {
                         node.log("Initializing crypto...");
                         await node.matrixClient.initCrypto();
                         node.matrixClient.getCrypto().globalBlacklistUnverifiedDevices = false; // prevent errors from unverified devices
+                        node.matrixClient.getCrypto().globalErrorOnUnknownDevices  = !node.allowUnknownDevices;
                     }
                     node.log("Connecting to Matrix server...");
                     await node.matrixClient.startClient({


### PR DESCRIPTION
Allows for sending messages with unknown unverified devices in the room. While not ideal to have enabled, this can provide a workaround for #118 until verification is fully implemented. If this gets merged in I can make the corresponding change to the e2ee branch as well.



### Testing 
I tested sending with it both enabled and disabled when encountering the error in the linked issue, confirming messages could then be sent. Let me know if there are any other specific tests I should do though.

![image](https://github.com/user-attachments/assets/cc4ee693-06ae-4486-b41e-a9147335d391)



