### PR TITLE
Support default plaintext in msg.format

### DIFF
--- a/src/matrix-send-message.js
+++ b/src/matrix-send-message.js
@@ -127,7 +127,7 @@ module.exports = function(RED) {
                 }
 
                 if(msgFormat === 'msg.format') {
-                    if(!Object.keys(msg).includes(format)) {
+                    if(!Object.keys(msg).includes("format")) {
                         node.error("Message format is set to be passed in via msg.format but was not defined", msg);
                         return;
                     }

--- a/src/matrix-send-message.js
+++ b/src/matrix-send-message.js
@@ -127,7 +127,7 @@ module.exports = function(RED) {
                 }
 
                 if(msgFormat === 'msg.format') {
-                    if(!msg.format) {
+                    if(!Object.keys(msg).includes(format)) {
                         node.error("Message format is set to be passed in via msg.format but was not defined", msg);
                         return;
                     }

--- a/src/matrix-send-message.js
+++ b/src/matrix-send-message.js
@@ -127,7 +127,7 @@ module.exports = function(RED) {
                 }
 
                 if(msgFormat === 'msg.format') {
-                    if(!Object.keys(msg).includes("format")) {
+                    if(!Object.hasOwn(msg, 'format')) {
                         node.error("Message format is set to be passed in via msg.format but was not defined", msg);
                         return;
                     }


### PR DESCRIPTION
To format the text plaintext, the configuration uses an empty string.

However passing an empty string to `msg.format` fails the check and yields `Message format is set to be passed in via msg.format but was not defined`, since the empty string evaluates to false in JavaScript.

Instead this now checks if the key is defined on the object wich allows to use values that JavaScript normally evaluates to false (like empty string).

If I miss understood how it is supposed to work feel free to close this pull request.

