### PR TITLE
Add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,81 @@
+name: Publish to npm
+
+# Publishes the package to npm whenever a GitHub Release is published.
+# It publishes the exact commit the release tag points to, so a pre-release
+# can be cut from any branch (e.g. a beta off `dev`) without that branch
+# having to be merged into master first.
+#
+# The release tag is the source of truth for the version:
+#   - Stable tag (e.g. v1.2.3)             -> published to the "latest"
+#                                             dist-tag; the version bump is
+#                                             committed back to master.
+#   - Pre-release tag (e.g. v1.2.3-beta.1) -> published to a matching dist-tag
+#                                             ("beta", "rc", ...); does NOT
+#                                             become "latest" and is NOT
+#                                             committed back to master.
+#
+# Authentication uses npm Trusted Publishing (OIDC) - no token or secret is
+# needed. Configure a trusted publisher for this package on npmjs.com:
+#   Repository: Skylar-Tech/node-red-contrib-matrix-chat
+#   Workflow:   publish.yml
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # commit the version bump back to master
+      id-token: write   # npm Trusted Publishing (OIDC) + provenance
+    steps:
+      - name: Check out the released commit
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Update npm
+        # Trusted Publishing requires npm 11.5.1 or newer; Node 22 ships npm 10.
+        run: npm install -g npm@latest
+
+      - name: Determine version and dist-tag
+        id: ver
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$VERSION" == *-* ]]; then
+            # pre-release, e.g. 1.0.0-beta.1 -> dist-tag "beta"
+            DIST_TAG="${VERSION#*-}"
+            DIST_TAG="${DIST_TAG%%.*}"
+            PRERELEASE=true
+          else
+            DIST_TAG=latest
+            PRERELEASE=false
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "Publishing $VERSION to npm dist-tag '$DIST_TAG' (prerelease=$PRERELEASE)"
+
+      - name: Set version
+        run: npm version "${{ steps.ver.outputs.version }}" --no-git-tag-version --allow-same-version
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public --tag "${{ steps.ver.outputs.dist_tag }}"
+
+      - name: Commit version bump back to master
+        if: steps.ver.outputs.prerelease == 'false'
+        run: |
+          if git diff --quiet; then
+            echo "package.json already at ${{ steps.ver.outputs.version }}; nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "Set version to ${{ steps.ver.outputs.version }}"
+          git push origin HEAD:master \
+            || echo "::warning::Could not push the version bump to master (branch protection?). The package was still published."


### PR DESCRIPTION
Adds the GitHub Actions workflow that publishes the package to npm whenever a GitHub Release is published.

It is added to `master` on its own (ahead of the v1.0.0 work in #142) so that pre-releases can be cut from `dev` and published to npm under a `beta` dist-tag, without merging the work-in-progress v1.0.0 changes into `master`.

- Publishes the exact commit the release tag points to (so a beta tagged off `dev` publishes `dev`'s code).
- Stable tags (e.g. `v1.2.3`) publish to the `latest` dist-tag; pre-release tags (e.g. `v1.2.3-beta.1`) publish to a matching tag (`beta`, `rc`, ...) and never become `latest`.
- Authenticates with npm Trusted Publishing (OIDC) — no token or secret stored.
